### PR TITLE
chore: use PROJECT_SOURCE instead of PROJECTS_ROOT

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-d3eab13
+      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
       memoryLimit: 3Gi
       endpoints:
         - exposure: none
@@ -18,22 +18,28 @@ components:
       volumeMounts:
         - name: m2
           path: /home/user/.m2
+
   - name: m2
     volume:
       size: 1G
+
 commands:
-- id: build-the-project
-  exec:
-    commandLine: JAVA_HOME=$JAVA_HOME_8 mvn clean install
-    component: tools
-    workingDir: "${PROJECTS_ROOT}/fuse-rest-http-booster"
-- id: run-the-services
-  exec:
-    commandLine: JAVA_HOME=$JAVA_HOME_8 mvn spring-boot:run -DskipTests
-    component: tools
-    workingDir: "${PROJECTS_ROOT}/fuse-rest-http-booster"
-- id: run-the-services-debug
-  exec:
-    commandLine: JAVA_HOME=$JAVA_HOME_8 mvn spring-boot:run -DskipTests -Drun.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"
-    component: tools
-    workingDir: "${PROJECTS_ROOT}/fuse-rest-http-booster"
+  - id: build-project
+    exec:
+      commandLine: JAVA_HOME=$JAVA_HOME_8 mvn clean install
+      component: tools
+      workingDir: "${PROJECT_SOURCE}"
+
+  - id: run-services
+    exec:
+      commandLine: JAVA_HOME=$JAVA_HOME_8 mvn spring-boot:run -DskipTests
+      component: tools
+      workingDir: "${PROJECT_SOURCE}"
+
+  - id: debug-services
+    exec:
+      commandLine: |
+        JAVA_HOME=$JAVA_HOME_8 mvn spring-boot:run -DskipTests \
+        -Drun.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"
+      component: tools
+      workingDir: "${PROJECT_SOURCE}"


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- Replaces PROJECTS_ROOT environment variable on PROJECT_SOURCE in devfile commands
- Bumps to the latest tag of universal developer image
