### PR TITLE
chore: add missing recommendations to .vscode/extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,8 @@
   "recommendations": [
     "redhat.vscode-xml",
     "redhat.vscode-apache-camel",
-    "redhat.java"
+    "redhat.java",
+    "vscjava.vscode-java-debug",
+    "vscjava.vscode-java-test"
   ]
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Add `vscjava.vscode-java-debug` and `vscjava.vscode-java-test` extensions to recommendations in `.vscode/extensions.json`

Solves https://github.com/eclipse/che/issues/21644
