### PR TITLE
chore(devfile) use ubi-latest tag for UDI

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
       memoryLimit: 3Gi
       endpoints:
         - exposure: none


### PR DESCRIPTION
chore(devfile) use ubi-latest tag for UDI

![Screenshot from 2023-03-21 14-05-57](https://user-images.githubusercontent.com/1271546/226601231-03b4cdad-8f66-448a-a267-8792b11cfeb7.png)


Related issue: https://github.com/eclipse/che/issues/21979